### PR TITLE
Remove HTML error parsing

### DIFF
--- a/one_hit_wonders.py
+++ b/one_hit_wonders.py
@@ -100,16 +100,7 @@ class OneHitWonders:
             error_str = 'Bad HTML status from Spotify: {0} {1}'.format(r1.status, r1.reason)
             raise RuntimeError(error_str)
 
-        body = r1.read()
-
-        if body[0:6] == '<html>':
-            parsed_html = BeautifulSoup(body)
-            html_error = parsed_html.body.find('h1').text
-
-            error_str = 'Bad API response from Spotify ({}), probably an error in the API query.'.format(html_error)
-            raise RuntimeError(error_str)
-
-        results = json.loads(body)
+        results = json.loads(r1.read())
 
         return results
 


### PR DESCRIPTION
The block in which an error is parsed out of an HTML response in redundant. If you try to hit a bad endpoint, the error will be caught on [line 99](https://github.com/devinbrady/one-hit-wonders/blob/7f9065471006119c6da96048bb4827d6fc26785e/one_hit_wonders.py#L99):

```
Traceback (most recent call last):
  File "one_hit_wonders.py", line 150, in <module>
    OneHitWonders()
  File "one_hit_wonders.py", line 53, in __init__
    top_tracks = self.get_top_tracks(artist_id)
  File "one_hit_wonders.py", line 88, in get_top_tracks
    results = self.query_spotify("/v1/artists/{0}/top-tracdddks?country={1}".format(artist_id, self.__country_code))
  File "one_hit_wonders.py", line 101, in query_spotify
    raise RuntimeError(error_str)
RuntimeError: Bad HTML status from Spotify: 404 Not Found
```

This removes the block that parses the error from an HTML response.
